### PR TITLE
Don't resize when fbo.shape hasn't changed

### DIFF
--- a/fbo.js
+++ b/fbo.js
@@ -194,6 +194,9 @@ Object.defineProperty(proto, "shape", {
       throw new Error("gl-fbo: Can't resize destroyed FBO")
     }
 
+    if (this._shape[0] === x[0]|0 &&
+        this._shape[1] === x[1]|0) return
+
     var gl = this.gl
     
     //Check parameter ranges


### PR DESCRIPTION
A small tweak to avoid accidentally resizing the FBO too frequently. Also makes it easy to stick this in your render loop:

``` javascript
fbo.shape = [canvas.height, canvas.width]
```

And not have to listen to resize events etc. Thanks! :)
