### PR TITLE
fix bindTexture: invalid target warning

### DIFF
--- a/fbo.js
+++ b/fbo.js
@@ -21,7 +21,7 @@ function saveFBOState(gl) {
 function restoreFBOState(gl, data) {
   gl.bindFramebuffer(gl.FRAMEBUFFER, data[0])
   gl.bindRenderbuffer(gl.RENDERBUFFER, data[1])
-  gl.bindTexture(gl.TEXUTRE_2D, data[2])
+  data[2] && gl.bindTexture(gl.TEXUTRE_2D, data[2])
 }
 
 function lazyInitColorAttachments(gl, ext) {


### PR DESCRIPTION
I guess this happens on the first restore, but it's worth keeping this clean of warnings!
