### PR TITLE
Fixed undefined variable error.

### DIFF
--- a/fbo.js
+++ b/fbo.js
@@ -108,7 +108,7 @@ function rebuildFBO(fbo) {
       ext.drawBuffersWEBGL(colorAttachmentArrays[0])
     }
   } else if(numColors > 1) {
-    ext.drawBuffersWEBGL(colorAttachmentArrays[numColor])
+    ext.drawBuffersWEBGL(colorAttachmentArrays[numColors])
   }
 
   //Allocate depth/stencil buffers


### PR DESCRIPTION
When trying to use more than one color buffer, fbo initialization fails due to undefined variable reference.