### PR TITLE
Remove webglew

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Frame buffer object wrapper for WebGL",
   "main": "fbo.js",
   "dependencies": {
-    "webglew": "^1.0.0",
     "gl-texture2d": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Based on some previous discussion, it doesn't seem like we really need webglew anymore.  Also, it poses some problems when trying to deal with context loss recovery and bloats bundle size due to the weird weakmap dependencies.  

As a result, I think we should just kill it across all the modules in stackgl, then deprecate it.

All in favor?

@mattdesl @hughsk 