### PR TITLE
add support for half-float and probe for format renderability, closes…

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,20 @@ Creates a wrapped framebuffer object
 * `shape` is a length 2 array encoding the `[width, height]` of the frame buffer
 * `options` is an object containing the following optional properties:
 
-    + `options.preferFloat` Upgrade to floating point if available, otherwise fallback to 8bit. (default `false`)
-    + `options.float` Use floating point textures (default `false`)
+    + `options.float` Require 32-bit floating point textures (default `false`)
+    + `options.halfFloat` Require 16-bit floating point textures (default `false`)
+    + `options.preferFloat` Upgrade to floating point if available, fallback to 16bit then 8bit. (default `false`)
+    + `options.preferHalfFloat` Upgrade to half-floating point if available, fallback to 32bit then 8bit. (default `false`)
     + `options.color`  The number of color buffers to create (default `1`)
     + `options.depth` If fbo has a depth buffer (default: `true`)
     + `options.stencil` If fbo has a stencil buffer (default: `false`)
+
+If more than one of the following options are true, then precedence is in the following order: 
+
+    + `options.float`
+    + `options.halfFloat`
+    + `options.preferFloat`
+    + `options.preferHalfFloat`
 
 ## Methods
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "authors": [
     "Mikola Lysenko <mikolalysenko@gmail.com> (http://0fps.net)",
     "Hugh Kennedy <hughskennedy@gmail.com> (http://hughsk.io)",
-    "Chris Dickinson <chris@neversaw.us> (http://neversaw.us)"
+    "Chris Dickinson <chris@neversaw.us> (http://neversaw.us)",
+    "Evan Wies <evan@neomantra.net> (http://neomantra.net)"
   ],
   "license": "MIT",
   "readmeFilename": "README.md",


### PR DESCRIPTION
… #11

Adds two new `options`:
- like `options.float`, `options.halfFloat` fails if it cannot create
  the half-float texture
- like `options.preferFloat`, `options.preferHalfFloat` will try
  half-float, then float, then fail to 8-bit.
- `options.preferFloat` now tries a half-flat before failing to 8-bit

The function `isFormatRenderable` checks if a given format can
actually be rendered to by attaching a texture to a framebuffer.
Checking the WebGL extension alone is insufficient due to variations
in implementations (e.g. iOS supports OES_texture_float, but only
for reading, not for writing). As this is a FBO and thus intended for
writing, this extra check is important.
